### PR TITLE
timeslot overlay fix

### DIFF
--- a/GymFree/app/src/main/java/edu/utap/gymfree/ui/book/SelectAdapter.kt
+++ b/GymFree/app/src/main/java/edu/utap/gymfree/ui/book/SelectAdapter.kt
@@ -60,7 +60,7 @@ class SelectAdapter(private var viewModel: SelectViewModel)
                         .supportFragmentManager
                             .beginTransaction()
                             .replace(R.id.nav_host_fragment, TimeslotFragment.newInstance(item.rowID))
-                            .addToBackStack(null)
+                            .addToBackStack("select")
                             .commit()
 
             }

--- a/GymFree/app/src/main/java/edu/utap/gymfree/ui/book/TimeslotAdapter.kt
+++ b/GymFree/app/src/main/java/edu/utap/gymfree/ui/book/TimeslotAdapter.kt
@@ -12,6 +12,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.findFragment
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -54,13 +55,15 @@ class TimeslotAdapter(private var viewModel: TimeslotViewModel)
             val slots = Html.fromHtml(item.startTime).toString() + " " + Html.fromHtml(item.endTime).toString()
             timeslotText.text = Html.fromHtml(slots)
 
+            rowText.visibility = View.VISIBLE
+
             bookBut.setOnClickListener {
-                (itemView.context as FragmentActivity).supportFragmentManager.popBackStack()
+                (itemView.context as FragmentActivity)
+                        .supportFragmentManager
+                        .popBackStack("select", FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 Log.d(TAG, "POPPED")
             }
 
-
-            rowText.visibility = View.VISIBLE
         }
 
         fun bind(item: Timeslot?) {

--- a/GymFree/app/src/main/res/layout/fragment_select_locations.xml
+++ b/GymFree/app/src/main/res/layout/fragment_select_locations.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.book.SelectFragment">
+    tools:context=".ui.book.SelectFragment"
+    android:background="@color/white">
 
     <LinearLayout
         android:id="@+id/userControls"

--- a/GymFree/app/src/main/res/layout/fragment_timeslots.xml
+++ b/GymFree/app/src/main/res/layout/fragment_timeslots.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.book.TimeslotFragment">
+    tools:context=".ui.book.TimeslotFragment"
+    android:background="@color/white">
 
     <LinearLayout
         android:id="@+id/userControls"


### PR DESCRIPTION
**Fix**
- Fixed the bug where the timeslots fragment overlays on top of select fragment by adding a name to the backstack, and setting background color of the fragment to white

**Testing**
Fragment is successfully being removed from backstack and overlay is no longer there
see below

<img width="373" alt="Screen Shot 2020-11-25 at 3 28 23 AM" src="https://user-images.githubusercontent.com/6621180/100208841-c6e57800-2ece-11eb-84b8-1d8ee738761f.png">

