### PR TITLE
pop backstack on nav change and back button

### DIFF
--- a/GymFree/app/src/main/java/edu/utap/gymfree/MainActivity.kt
+++ b/GymFree/app/src/main/java/edu/utap/gymfree/MainActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.Barrier
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.fragment.app.FragmentManager
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -66,6 +67,14 @@ class MainActivity : AppCompatActivity() {
 
         fab.setOnClickListener {
             navController.navigate(R.id.navigation_create)
+        }
+        navController.addOnDestinationChangedListener { controller, destination, arguments ->
+            val count = supportFragmentManager.backStackEntryCount
+            Log.d(TAG, "NAV CHANGED: $count")
+            if (count != 0){
+                Log.d(TAG, "~~POPPED")
+                supportFragmentManager.popBackStack("select", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            }
         }
 
 
@@ -147,6 +156,7 @@ class MainActivity : AppCompatActivity() {
                 Log.d(TAG, "ERROR: Sign in Failed")
             }
         }
+
     }
 
     public override fun onStart() {
@@ -177,6 +187,18 @@ class MainActivity : AppCompatActivity() {
 //                    .commit()
         }
     }
+    override fun onBackPressed(){
+        val count = supportFragmentManager.backStackEntryCount
+        Log.d(TAG, "~~BACK WAS PRESSED: $count")
+        if (count != 0){
+            Log.d(TAG, "~~POPPED")
+            supportFragmentManager.popBackStack("select", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        }
+        else{
+            super.onBackPressed()
+        }
+    }
+
 
 
 }


### PR DESCRIPTION
**Notes**
- fixed overlay bug when changing navigation or pressing the back button when there is a fragment on the backstack. 
- override onBackPressed to pop backstack when back is pressed
- pop backstack when nav destination is changed

**Testing**
- observed fix, see below

Before:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/6621180/100788274-798b6e00-33da-11eb-848f-762d557c051f.gif)

After:
<img width="387" alt="Screen Shot 2020-12-01 at 1 12 12 PM" src="https://user-images.githubusercontent.com/6621180/100786627-084abb80-33d8-11eb-9444-9c13c94a0352.png">

